### PR TITLE
Check if shippingMethod exists before accessing

### DIFF
--- a/src/view/frontend/web/js/mixin/select-shipping-method-mixin.js
+++ b/src/view/frontend/web/js/mixin/select-shipping-method-mixin.js
@@ -42,8 +42,8 @@ define([
             var payload = {
                 addressInformation: {
                     'shipping_address': quote.shippingAddress(),
-                    'shipping_method_code': shippingMethod['method_code'],
-                    'shipping_carrier_code': shippingMethod['carrier_code']
+                    'shipping_method_code': shippingMethod ? shippingMethod['method_code'] : null,
+                    'shipping_carrier_code': shippingMethod ? shippingMethod['carrier_code'] : null
                 }
             };
 


### PR DESCRIPTION
Seen an issue in compatibility between other modules providing null as a shippingMethod - this seems like a safe way of checking so this mixin doesn't throw an exception